### PR TITLE
feat: :sparkles: adding timeout pattern as a feature to recloser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,13 @@ repository = "https://github.com/lerouxrgd/recloser"
 license = "MIT"
 readme = "README.md"
 
+[features]
+timeout = ["async-io"]
+
 [dependencies]
 crossbeam = "0.8"
 pin-project = "1"
+async-io = { version="1.13.0", optional=true }
 
 [dev-dependencies]
 async-std = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@ pub enum Error<E> {
     Inner(E),
     /// Directly returned when in `Open(_)` state.
     Rejected,
+    /// Returned when specific duration is reached
+    Timeout
 }
 
 /// A trait used to determine whether an `E` should be considered as a failure.


### PR DESCRIPTION
Description

@lerouxrgd First off, thank you for an excellent contribution - recloser.

In lines of resiliency, I'd like to contribute timeout pattern into `recloser` as a feature. This is currently not present in the library and request to keep waiting for response even though circuit breaker is present. 

Changes: 
1. Times out is added as a input parameter which works based on delay timer
2. If specific request reaches the timeout specified, it is calculated for towards failure rate 

   