### PR TITLE
Introduce support to WASM compilation by avoiding std lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-crossbeam-epoch = "0.9"
-pin-project = "1"
+crossbeam-epoch = { version = "0.9", default-features = false, features = ["alloc"] }
+pin-project = { version = "1", optional = true }
+
+[features]
+default = ["async"]
+async = ["dep:pin-project"]
 
 [dev-dependencies]
 async-std = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "async")]
 mod r#async;
 mod error;
 mod recloser;
 mod ring_buffer;
 
 pub use crate::error::{AnyError, Error, ErrorPredicate};
+#[cfg(feature = "async")]
 pub use crate::r#async::{AsyncRecloser, RecloserFuture};
 pub use crate::recloser::{Recloser, RecloserBuilder};
 


### PR DESCRIPTION
Hi, thanks for this library. We'd like to use this library on a WASM context, so I'm contributing back this changes :)

This commit introduce compilation features to allow this library to be used on `wasm32-unknown-unknown` target.

The `crossbeam_epoch` library already have support to compile on a `no_std` environment, as long as we don't use the global `crossbeam_epoch::epoch::pin` lock, which is feature-gated for `std` environments.

In order to compile this library for WASM, the following changes were performed:
- Instead of a global epoch value, we now use a per `Recloser` epoch lock.
- We feature-gate the AsyncRecloser behind a `feature=async` feature flag.

To avoid breaking users, the `async` flag is provided as a `default` feature. Now, this library can be compiled to a WASM environment using:

```sh
cargo build --release --target wasm32-unknown-unknown --no-default-features
```

And now can be included like this on a WASM library:

```toml
[dependencies]
recloser = { version = "*", default-features = false }
```