### PR TITLE
adding optional OpenWaitStrategy

### DIFF
--- a/benches/recloser.rs
+++ b/benches/recloser.rs
@@ -7,7 +7,7 @@ use num_cpus;
 use rayon::prelude::*;
 
 use failsafe::{CircuitBreaker, Config, backoff, failure_policy};
-use recloser::{OpenWaitStrategy, Recloser};
+use recloser::Recloser;
 
 const ITER_C: u64 = 10_000;
 
@@ -38,9 +38,7 @@ fn make_recloser_with_strategy() -> Recloser {
         .closed_len(10)
         .half_open_len(5)
         .open_wait(Duration::from_secs(1))
-        .open_wait_strategy(OpenWaitStrategy::new(Duration::from_secs(2), |_, wait| {
-            wait
-        }))
+        .open_wait_strategy(|_, open_wait| open_wait)
         .build()
 }
 

--- a/benches/recloser.rs
+++ b/benches/recloser.rs
@@ -38,7 +38,9 @@ fn make_recloser_with_strategy() -> Recloser {
         .closed_len(10)
         .half_open_len(5)
         .open_wait(Duration::from_secs(1))
-        .open_wait_strategy(OpenWaitStrategy::new(Duration::from_secs(2), |_, wait| wait))
+        .open_wait_strategy(OpenWaitStrategy::new(Duration::from_secs(2), |_, wait| {
+            wait
+        }))
         .build()
 }
 
@@ -137,8 +139,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("failsafe_simple", |b| b.iter(|| failsafe_simple()));
     c.bench_function("recloser_concurrent", |b| b.iter(|| recloser_concurrent()));
     c.bench_function("failsafe_concurrent", |b| b.iter(|| failsafe_concurrent()));
-    c.bench_function("recloser_simple_with_strategy", |b| b.iter(|| recloser_simple_with_strategy()));
-    c.bench_function("recloser_concurrent_with_strategy", |b| b.iter(|| recloser_concurrent_with_strategy()));
+    c.bench_function("recloser_simple_with_strategy", |b| {
+        b.iter(|| recloser_simple_with_strategy())
+    });
+    c.bench_function("recloser_concurrent_with_strategy", |b| {
+        b.iter(|| recloser_concurrent_with_strategy())
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod ring_buffer;
 
 pub use crate::r#async::{AsyncRecloser, RecloserFuture};
 pub use crate::error::{AnyError, Error, ErrorPredicate};
-pub use crate::recloser::{OpenWaitStrategy, RECLOSER_EVENT, Recloser, RecloserBuilder};
+pub use crate::recloser::{RECLOSER_EVENT, Recloser, RecloserBuilder, WaitStrategy};
 
 #[cfg(doctest)]
 mod doctests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod ring_buffer;
 
 pub use crate::r#async::{AsyncRecloser, RecloserFuture};
 pub use crate::error::{AnyError, Error, ErrorPredicate};
-pub use crate::recloser::{RECLOSER_EVENT, Recloser, RecloserBuilder};
+pub use crate::recloser::{RECLOSER_EVENT, Recloser, RecloserBuilder, OpenWaitStrategy};
 
 #[cfg(doctest)]
 mod doctests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod ring_buffer;
 
 pub use crate::r#async::{AsyncRecloser, RecloserFuture};
 pub use crate::error::{AnyError, Error, ErrorPredicate};
-pub use crate::recloser::{RECLOSER_EVENT, Recloser, RecloserBuilder, OpenWaitStrategy};
+pub use crate::recloser::{OpenWaitStrategy, RECLOSER_EVENT, Recloser, RecloserBuilder};
 
 #[cfg(doctest)]
 mod doctests {

--- a/src/recloser.rs
+++ b/src/recloser.rs
@@ -275,9 +275,12 @@ impl core::fmt::Debug for Recloser {
             open_wait,
             open_wait_strategy,
             state,
+            #[cfg(feature = "tracing")]
+            state_started_ts,
         } = self;
-        f.debug_struct("Recloser")
-            .field("threshold_closed", &threshold_closed)
+
+        let mut ds = f.debug_struct("Recloser");
+        ds.field("threshold_closed", &threshold_closed)
             .field("threshold_half_open", &threshold_half_open)
             .field("closed_len", &closed_len)
             .field("half_open_len", &half_open_len)
@@ -288,8 +291,12 @@ impl core::fmt::Debug for Recloser {
                     .as_ref()
                     .map(|_| "Some(Box<dyn WaitStrategy>)"),
             )
-            .field("state", &state)
-            .finish()
+            .field("state", &state);
+
+        #[cfg(feature = "tracing")]
+        ds.field("state_started_ts", &state_started_ts);
+
+        ds.finish()
     }
 }
 

--- a/src/recloser.rs
+++ b/src/recloser.rs
@@ -286,8 +286,8 @@ impl State {
     fn name(&self) -> &'static str {
         match self {
             State::Closed(_) => "Closed",
-            State::Open(_) => "Open",
-            State::HalfOpen(_) => "HalfOpen",
+            State::Open(_, _) => "Open",
+            State::HalfOpen(_, _) => "HalfOpen",
         }
     }
 }

--- a/src/recloser.rs
+++ b/src/recloser.rs
@@ -348,7 +348,7 @@ impl RecloserBuilder {
     }
     
     pub fn open_wait_strategy(mut self, open_wait_strategy: OpenWaitStrategy) -> Self {
-        self.open_wait_strategy = self.open_wait_strategy;
+        self.open_wait_strategy = Some(open_wait_strategy);
         self
     }
 

--- a/src/recloser.rs
+++ b/src/recloser.rs
@@ -500,8 +500,8 @@ mod tests {
     fn assert_state_transitions(recl: &Recloser, guard: &Guard) {
         
         //  result:  e e e x ____ ✓ e e x  ____ ✓ ✓ ✓ 
-        //   state:      o o      h h o o       h h c
-        //    flap:      1 1      1 1 2 2       2 2
+        //   state:  c c o o      h h o o       h h c
+        //    flap:  - - 1 1      1 1 2 2       2 2 -
 
         // Fill the State::Closed ring buffer
         for _ in 0..2 {

--- a/src/recloser.rs
+++ b/src/recloser.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 use fake_clock::FakeClock as Instant;
+use std::fmt::Formatter;
+use std::ops::Deref;
 #[cfg(feature = "tracing")]
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
@@ -25,6 +27,7 @@ pub struct Recloser {
     closed_len: usize,
     half_open_len: usize,
     open_wait: Duration,
+    open_wait_strategy: Option<OpenWaitStrategy>,
     state: Atomic<State>,
     #[cfg(feature = "tracing")]
     state_started_ts: AtomicU64,
@@ -81,10 +84,10 @@ impl Recloser {
         // Safety: safe because `Shared::null()` is never used.
         match unsafe { shared.deref() } {
             State::Closed(_) => true,
-            State::HalfOpen(_) => true,
-            _old_state @ State::Open(until) => {
+            State::HalfOpen(_,_) => true,
+            _old_state @ State::Open(until,fp) => {
                 if Instant::now() > *until {
-                    let new_state = State::HalfOpen(RingBuffer::new(self.half_open_len));
+                    let new_state = State::HalfOpen(RingBuffer::new(self.half_open_len), *fp);
                     #[cfg(feature = "tracing")]
                     let new_state_name = new_state.name();
 
@@ -133,7 +136,7 @@ impl Recloser {
             State::Closed(rb) => {
                 rb.set_current(false);
             }
-            _old_state @ State::HalfOpen(rb) => {
+            _old_state @ State::HalfOpen(rb, _) => {
                 let failure_rate = rb.set_current(false);
                 if failure_rate > -1.0 && failure_rate <= self.threshold_half_open {
                     let new_state = State::Closed(RingBuffer::new(self.closed_len));
@@ -171,7 +174,7 @@ impl Recloser {
                     }
                 }
             }
-            State::Open(_) => (),
+            State::Open(_,_) => (),
         };
     }
 
@@ -182,7 +185,7 @@ impl Recloser {
             _old_state @ State::Closed(rb) => {
                 let failure_rate = rb.set_current(true);
                 if failure_rate > -1.0 && failure_rate >= self.threshold_closed {
-                    let new_state = State::Open(Instant::now() + self.open_wait);
+                    let new_state = State::Open(Instant::now() + self.open_wait, 1);
                     #[cfg(feature = "tracing")]
                     let new_state_name = new_state.name();
 
@@ -217,10 +220,16 @@ impl Recloser {
                     }
                 }
             }
-            _old_state @ State::HalfOpen(rb) => {
+            _old_state @ State::HalfOpen(rb,fc) => {
                 let failure_rate = rb.set_current(true);
                 if failure_rate > -1.0 && failure_rate >= self.threshold_half_open {
-                    let new_state = State::Open(Instant::now() + self.open_wait);
+                   
+                    let new_wait = match self.open_wait_strategy.as_ref() {
+                        None => Instant::now() + self.open_wait,
+                        Some(strategy) => Instant::now() + strategy.next_wait(*fc, self.open_wait)
+                    };
+                    let new_state = State::Open(new_wait, fc + 1);
+                    
                     #[cfg(feature = "tracing")]
                     let new_state_name = new_state.name();
 
@@ -255,7 +264,7 @@ impl Recloser {
                     }
                 }
             }
-            State::Open(_) => (),
+            State::Open(_, _) => (),
         };
     }
 }
@@ -265,11 +274,12 @@ impl Recloser {
 enum State {
     /// Allows calls until a failure_rate threshold is reached.
     Closed(RingBuffer),
-    /// Rejects all calls until the future [`Instant`] is reached.
-    Open(Instant),
+    /// Rejects all calls until the future [`Instant`] is reached. Carries the seed for flap count.
+    Open(Instant, u32),
     /// Allows calls until the underlying [`RingBuffer`] is full,
     /// then calculates a failure_rate based on which the next transition will happen.
-    HalfOpen(RingBuffer),
+    /// Carries flap_count - number of times the circuit breaker transitioned between Open <-> HalfOpen
+    HalfOpen(RingBuffer, u32),
 }
 
 #[cfg(feature = "tracing")]
@@ -291,6 +301,7 @@ pub struct RecloserBuilder {
     closed_len: usize,
     half_open_len: usize,
     open_wait: Duration,
+    open_wait_strategy: Option<OpenWaitStrategy>
 }
 
 impl RecloserBuilder {
@@ -301,6 +312,7 @@ impl RecloserBuilder {
             closed_len: 100,
             half_open_len: 10,
             open_wait: Duration::from_secs(30),
+            open_wait_strategy: None
         }
     }
 
@@ -334,6 +346,11 @@ impl RecloserBuilder {
         self.open_wait = open_wait;
         self
     }
+    
+    pub fn open_wait_strategy(mut self, open_wait_strategy: OpenWaitStrategy) -> Self {
+        self.open_wait_strategy = self.open_wait_strategy;
+        self
+    }
 
     pub fn build(self) -> Recloser {
         let state = State::Closed(RingBuffer::new(self.closed_len));
@@ -357,6 +374,7 @@ impl RecloserBuilder {
             closed_len: self.closed_len,
             half_open_len: self.half_open_len,
             open_wait: self.open_wait,
+            open_wait_strategy: self.open_wait_strategy,
             state: Atomic::new(state),
             #[cfg(feature = "tracing")]
             state_started_ts: AtomicU64::new(state_started),
@@ -369,6 +387,39 @@ impl Default for Recloser {
         Recloser::custom().build()
     }
 }
+
+pub struct OpenWaitStrategy {
+    max_wait: Duration,
+    next_wait: Box<dyn Fn(u32, Duration) -> Duration + Send + Sync>
+}
+
+impl OpenWaitStrategy {
+    
+    pub fn new<F>(max_wait: Duration, strategy: F) -> Self
+    where
+        F: Fn(u32, Duration) -> Duration + Send + Sync + 'static {
+        Self {
+            max_wait,
+            next_wait: Box::new(strategy)
+        }
+    }
+    
+    pub fn next_wait(&self, flap_count: u32, open_wait: Duration) -> Duration {
+        let wait = self.next_wait.deref()(flap_count, open_wait);
+        wait.min(self.max_wait)
+    }
+}
+
+impl std::fmt::Debug for OpenWaitStrategy {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenWaitStrategy")
+            .field("max_wait", &self.max_wait)
+            .field("next_wait", &"<function>")
+            .finish()
+    }
+}
+
+
 
 #[cfg(test)]
 mod tests {
@@ -424,6 +475,33 @@ mod tests {
             .build();
 
         let guard = &epoch::pin();
+        
+        assert_state_transitions(&recl, guard);
+    }
+
+    #[test]
+    fn recloser_correctness_with_strategy() {
+        
+        let recl = Recloser::custom()
+            .error_rate(0.5)
+            .closed_len(2)
+            .half_open_len(2)
+            .open_wait(Duration::from_secs(1))
+            .open_wait_strategy(
+                OpenWaitStrategy::new(Duration::from_secs(5), |_, wait| wait)
+            )
+            .build();
+
+        let guard = &epoch::pin();
+
+        assert_state_transitions(&recl, guard);
+    }
+    
+    fn assert_state_transitions(recl: &Recloser, guard: &Guard) {
+        
+        //  result:  e e e x ____ ✓ e e x  ____ ✓ ✓ ✓ 
+        //   state:      o o      h h o o       h h c
+        //    flap:      1 1      1 1 2 2       2 2
 
         // Fill the State::Closed ring buffer
         for _ in 0..2 {
@@ -437,34 +515,57 @@ mod tests {
             ));
         }
 
-        // Transition to State::Open on next call
+        // Transition to State::Open(1) on next call
         assert!(matches!(
             recl.call(|| Err::<(), ()>(())),
             Err(Error::Inner(()))
         ));
         assert!(matches!(
             unsafe { recl.state.load(Relaxed, guard).deref() },
-            State::Open(_)
+            State::Open(_,1)
         ));
         assert!(matches!(
             recl.call(|| Err::<(), ()>(())),
             Err(Error::Rejected)
         ));
 
-        // Transition to State::HalfOpen on first call after 1 sec
+        // Transition to State::HalfOpen(1) on first call after 1.5 sec
         sleep(1500);
         assert!(matches!(recl.call(|| Ok::<(), ()>(())), Ok(())));
         assert!(matches!(
             unsafe { recl.state.load(Relaxed, guard).deref() },
-            State::HalfOpen(_)
+            State::HalfOpen(_,1)
         ));
 
-        // Fill the State::HalfOpen ring buffer
+        // Fill the State::HaflOpen ring buffer
+        assert!(matches!(recl.call(|| Err::<(), ()>(())), Err(Error::Inner(()))));
+        assert!(matches!(
+            unsafe { recl.state.load(Relaxed, guard).deref() },
+            State::HalfOpen(_,1)
+        ));
+
+        // Transition to state State::Open(2) when failure rate above threshold
+        assert!(matches!(recl.call(|| Err::<(), ()>(())), Err(Error::Inner(()))));
+        assert!(matches!(
+            unsafe { recl.state.load(Relaxed, guard).deref() },
+            State::Open(_,2)
+        ));
+
+        assert!(matches!(
+            recl.call(|| Err::<(), ()>(())),
+            Err(Error::Rejected)
+        ));
+
+        // Transition to State::HalfOpen(2) on first call after 1.5 sec
+        sleep(1500);
         assert!(matches!(recl.call(|| Ok::<(), ()>(())), Ok(())));
         assert!(matches!(
             unsafe { recl.state.load(Relaxed, guard).deref() },
-            State::HalfOpen(_)
+            State::HalfOpen(_,2)
         ));
+
+        // Fill the State::HaflOpen ring buffer
+        assert!(matches!(recl.call(|| Ok::<(), ()>(())), Ok(())));
 
         // Transition to State::Closed when failure rate below threshold
         assert!(matches!(recl.call(|| Ok::<(), ()>(())), Ok(())));
@@ -510,5 +611,29 @@ mod tests {
         for handle in handles {
             handle.join().unwrap();
         }
+    }
+    
+    #[test]
+    fn test_custom_wait() {
+       
+        let open_wait = Duration::from_secs(1);
+        let strategy = OpenWaitStrategy::new(
+            Duration::from_secs(5),
+            |fc, wait| {
+                // simple exponential backoff
+                let base: u64 = 2;
+                let wait_ms: u64 = wait.as_millis() as u64;
+                let next_wait_ms = base.pow(fc) * wait_ms;
+                    
+                Duration::from_millis(next_wait_ms)
+            }
+        );
+        
+        // 1, 2, 4, 5, ... 5, ..,
+        assert_eq!(strategy.next_wait(0, open_wait), Duration::from_secs(1));
+        assert_eq!(strategy.next_wait(1, open_wait), Duration::from_secs(2));
+        assert_eq!(strategy.next_wait(2, open_wait), Duration::from_secs(4));
+        assert_eq!(strategy.next_wait(4, open_wait), Duration::from_secs(5));
+        assert_eq!(strategy.next_wait(10, open_wait), Duration::from_secs(5));
     }
 }

--- a/src/recloser.rs
+++ b/src/recloser.rs
@@ -85,9 +85,9 @@ impl Recloser {
         match unsafe { shared.deref() } {
             State::Closed(_) => true,
             State::HalfOpen(_,_) => true,
-            _old_state @ State::Open(until,fp) => {
+            _old_state @ State::Open(until,fc) => {
                 if Instant::now() > *until {
-                    let new_state = State::HalfOpen(RingBuffer::new(self.half_open_len), *fp);
+                    let new_state = State::HalfOpen(RingBuffer::new(self.half_open_len), *fc);
                     #[cfg(feature = "tracing")]
                     let new_state_name = new_state.name();
 


### PR DESCRIPTION
There are situations where it may be desirable to influence open-wait time when CB is flapping. To that effect, proposing an optional open-wait strategy upstream users can inject.