### PR TITLE
ring-buffer filling blindspot

### DIFF
--- a/src/recloser.rs
+++ b/src/recloser.rs
@@ -663,7 +663,7 @@ mod tests {
         for _ in 0..10 {
             _ = recl.call(|| Err::<(), ()>(()));
         }
-        // at this point, rng buffer is filled, the error rate is 0.9, yet if next call is a success, we miss
+        // at this point, rng buffer is filled, the error rate is 1.0, yet if next call is a success, we miss
         // the 'filling' point where rate can be calculated and used
         _ = recl.call(|| Ok::<(), ()>(()));
 
@@ -691,7 +691,7 @@ mod tests {
                 _ = recl.call(|| Err::<(), ()>(()));
             }
         }
-        // at this point, rng buffer is filled, the error rate is 0.9, and it takes another error to trip
+        // at this point, rng buffer is filled, the error rate is 0.5, and it takes another error to trip
         _ = recl.call(|| Err::<(), ()>(()));
         assert!(matches!(
             recl.call(|| Err::<(), ()>(())),

--- a/src/recloser.rs
+++ b/src/recloser.rs
@@ -669,7 +669,7 @@ mod tests {
 
         assert!(matches!(recl.call(|| Ok::<(), ()>(())), Ok(())));
 
-        // all subsequent calls will be permitted
+        // all subsequent calls will be permitted ?!
         for _ in 0..100 {
             assert!(matches!(recl.call(|| Ok::<(), ()>(())), Ok(())));
         }


### PR DESCRIPTION
I may have stumbled upon a small issue where CB won't trip under certain conditions, even if the error rate is exceeding the threshold. Proposing a fix.

Repro unit test [test_ring_buffer_filling_on_success](https://github.com/lerouxrgd/recloser/pull/10/files#diff-9e48861624fb94ad767137c1b3b879eb8b3d2d547a752afbe5827c10d73a894cR616):
CB would fail to trip on next successfull call.
 
